### PR TITLE
Fix url based flakes

### DIFF
--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -43,14 +43,19 @@ impl OsRebuildArgs {
         debug!("out_dir: {:?}", out_dir);
         debug!("out_link {:?}", out_link);
 
-        let flake_metadata =
-            fs::metadata(&self.flakeref).context("Failed to get metadata of flake")?;
-        let flake_uid = nix::unistd::Uid::from_raw(flake_metadata.uid());
-        debug!("flakeref is owned by root: {:?}", flake_uid.is_root());
+        // check if flake is owned by root
+        let flake_is_owned_by_root = match fs::metadata(&self.flakeref) {
+            Ok(metadata) => nix::unistd::Uid::from_raw(metadata.uid()).is_root(),
+            // flakeref is not found on system or user does not have permissions to get metadata
+            // so we assume it is not owned by root
+            // (could be a flake from github or the registry)
+            Err(_) => false, 
+        };
+        debug!("flakeref is owned by root: {:?}", flake_is_owned_by_root);
 
         // if we are root, then we do not need to elevate
         // if we are not root, and the flake is owned by root, then we need to elevate
-        let elevation_required = !effective_uid.is_root() && flake_uid.is_root();
+        let elevation_required = !effective_uid.is_root() && flake_is_owned_by_root;
 
         if self.common.pull {
             commands::CommandBuilder::default()


### PR DESCRIPTION
Fixes #8 
Allows use of url and registry based flakerefs

This pushes the error of a nonexistent flake to nix rather than nh.  

Before regardless of whether a flake was nonexistent locally or a non path flakeref:
```
Error:
   0: Failed to get metadata of flake
   1: No such file or directory (os error 2)

Location:
   src/nixos.rs:47
```
After when a path based flake is nonexistent locally:
```
error: could not find a flake.nix file
┏━ 1 Errors: 
┃ error: could not find a flake.nix file
┣━━━                                                            
┗━ ∑ ⚠ Exited with 1 errors reported by nix at 17:00:19 after 0s
Error: 
   0: Command exited with status Exited(1)

Location:
   src/commands.rs:170
```